### PR TITLE
fix: sipcapture/homer#625 used tsNs field for sorting of messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qxip-flow-panel",
-  "version": "10.0.9",
+  "version": "10.0.10",
   "description": "Test plugin to lern dev enveroument",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/SimplePanel.tsx
+++ b/src/components/SimplePanel.tsx
@@ -161,9 +161,15 @@ function formattingDataAndSortIt(data: any, sortType = 'none') {
     return unSortData;
   }
   const sortData = unSortData.sort((itemA: any, itemB: any) => {
-    const a = itemA.tsNs;
-    const b = itemB.tsNs;
-    return a < b ? -1 : a > b ? 1 : 0;
+    if (itemA.tsNs && itemB.tsNs) {
+      const a = itemA.tsNs;
+      const b = itemB.tsNs;
+      return a < b ? -1 : a > b ? 1 : 0;
+    } else { 
+      const a = itemA.Time;
+      const b = itemB.Time;
+      return a < b ? -1 : a > b ? 1 : 0;
+    }
   });
   if (sortType === 'time_old') {
     return sortData;


### PR DESCRIPTION
fix: sipcapture/homer#625 used tsNs field if exist, if not, used Time field, for sorting of messages